### PR TITLE
Caps lock rctrl

### DIFF
--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -13,6 +13,7 @@
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+SetCapsLockState, AlwaysOff ; diable the CapsLock key
 
 #InstallKeybdHook
 #UseHook
@@ -24,31 +25,39 @@ is_pre_x = 0
 ; C-Space status
 is_pre_spc = 0
 EmacsModeStat := false
-SetEmacsMode(false)
+SetEmacsMode(true)
+
+
 ;==========================
 ;Timer Subroutine
 ;==========================
 KeyX:
   SetTimer, KeyX, off
   global is_pre_x = 0
-  return 
+  return
+
+;==========================
+;Bind Caps to RCtrl
+;==========================
+CapsLock::RCtrl
 
 ;==========================
 ;Emacs mode toggle
 ;==========================
 ^`::
   SetEmacsMode(!EmacsModeStat)
+
 return
 
 SetEmacsMode(toActive) {
   local iconFile := toActive ? enabledIcon : disabledIcon
   local state := toActive ? "ON" : "OFF"
-  
+
   EmacsModeStat := toActive
   ;TrayTip, Emacs Everywhere, Emacs mode is %state%, 10, 1
   Menu, Tray, Icon, %iconFile%,
-  Menu, Tray, Tip, Emacs Everywhere`nEmacs mode is %state%  
-  
+  Menu, Tray, Tip, Emacs Everywhere`nEmacs mode is %state%
+
   Send {Shift Up}
 }
 
@@ -57,12 +66,12 @@ SetEmacsMode(toActive) {
 ; WinActive("ahk_class Chrome_WidgetWin_1") ||
 ;==========================
 is_target() {
-  ; force enable 
-  if(WinActive("MATLAB R2014b ahk_class SunAwtFrame")) {
+  ; force enable
+  if(WinActive("ahk_exe rider64.exe")) {
     return true
   }
-  ; for disable 
-  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame")) { 
+  ; for disable
+  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame")) {
     return false
   }
   return true
@@ -70,7 +79,7 @@ is_target() {
 
 IsInEmacsMode() {
   global EmacsModeStat
-  if (EmacsModeStat && is_target()) {
+if (EmacsModeStat && is_target()) {
     return true
   } else {
     return false
@@ -100,8 +109,8 @@ kill_line() {
   ;{
   ;  Send ^o
   ;}
-  
-  
+
+
   global is_pre_spc = 0
   Return
 }
@@ -229,7 +238,7 @@ next_line() {
 backward_char() {
   global
   if is_pre_spc
-    Send +{Left} 
+    Send +{Left}
   Else
     Send {Left}
   Return
@@ -254,9 +263,9 @@ scroll_down() {
 }
 
 singleLetterFallbackToDefault() {
-  state := GetKeyState("Capslock", "T") 
+  state := GetKeyState("Capslock", "T")
   If(state) {
-    Send +%A_ThisHotkey%  ; + for upper case 
+    Send +%A_ThisHotkey%  ; + for upper case
   }
   Else {
     Send %A_ThisHotkey%
@@ -266,7 +275,7 @@ singleLetterFallbackToDefault() {
 ;==========================
 ;Keybindings
 ;==========================
-^x::
+>^x::
   If IsInEmacsMode() {
     global is_pre_x = 1
     SetTimer, KeyX, 1000
@@ -277,14 +286,14 @@ singleLetterFallbackToDefault() {
 
 h::
   If (IsInEmacsMode() && is_pre_x) {
-    Send ^a  ; select all 
+    Send ^a  ; select all
     global is_pre_x = 0
   }
   Else
     singleLetterFallbackToDefault()
   Return
 
-^f::
+>^f::
   If IsInEmacsMode() {
     If is_pre_x {
       Send ^o
@@ -298,50 +307,57 @@ h::
   } Else
     Send %A_ThisHotkey%
   Return
-  
-^d::
+
++>^f::
+  If IsInEmacsMode()
+      Send +{Right}
+  Else
+    Send %A_ThisHotkey%
+  Return
+
+>^d::
   If IsInEmacsMode()
     delete_char()
   Else
     Send %A_ThisHotkey%
   Return
-^k::
+>^k::
   If IsInEmacsMode()
     kill_line()
   Else
     Send %A_ThisHotkey%
   Return
-^o::
+>^o::
   If IsInEmacsMode()
     open_line()
   Else
     Send %A_ThisHotkey%
   Return
-^g::
+>^g::
   If IsInEmacsMode()
     quit()
   Else
     Send %A_ThisHotkey%
   Return
-^j::
+>^j::
   If IsInEmacsMode()
     newline_and_indent()
   Else
     Send %A_ThisHotkey%
   Return
-^m::
+>^m::
   If IsInEmacsMode()
     newline()
   Else
     Send %A_ThisHotkey%
   Return
-^i::
+>^i::
   If IsInEmacsMode()
     indent_for_tab_command()
   Else
     Send %A_ThisHotkey%
   Return
-^s::
+>^s::
   If IsInEmacsMode()
   {
     If is_pre_x
@@ -352,31 +368,31 @@ h::
   Else
     Send %A_ThisHotkey%
   Return
-^r::
+>^r::
   If IsInEmacsMode()
     isearch_backward()
   Else
     Send %A_ThisHotkey%
   Return
-^w::
+>^w::
   If IsInEmacsMode()
     kill_region()
   Else
     Send %A_ThisHotkey%
   Return
-^y::
+>^y::
   If IsInEmacsMode()
     yank()
   Else
     Send %A_ThisHotkey%
   Return
-^/::
+>^/::
   If IsInEmacsMode()
     undo()
   Else
     Send %A_ThisHotkey%
   Return
-^@::
+>^Space::
   If IsInEmacsMode()
   {
     If is_pre_spc
@@ -387,49 +403,105 @@ h::
   Else
     Send %A_ThisHotkey%
   Return
-^a::
+>^a::
   If IsInEmacsMode()
     move_beginning_of_line()
   Else
     Send %A_ThisHotkey%
   Return
-^e::
++>^a::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    move_beginning_of_line()
+    is_pre_spc = 0
+  }
+  Else
+    Send %A_ThisHotkey%
+  Return
+>^e::
   If IsInEmacsMode()
     move_end_of_line()
   Else
     Send %A_ThisHotkey%
   Return
-^p::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    move_end_of_line()
+    is_pre_spc = 0
+  }
+  Else
+    Send %A_ThisHotkey%
+  Return
+>^p::
   If IsInEmacsMode()
     previous_line()
   Else
     Send %A_ThisHotkey%
   Return
-^n::
++>^p::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    previous_line()
+    is_pre_spc = 0
+  }
+  Else
+    Send %A_ThisHotkey%
+  Return
+>^n::
   If IsInEmacsMode()
     next_line()
   Else
     Send %A_ThisHotkey%
   Return
-^b::
++>^n::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    next_line()
+    is_pre_spc = 0
+  }
+  Else
+    Send %A_ThisHotkey%
+  Return
+>^b::
   If IsInEmacsMode()
     backward_char()
   Else
     Send %A_ThisHotkey%
   Return
-; page scroll are commented out 
-;^v::
-;  If IsInEmacsMode()
-;    scroll_down()
-;  Else
-;    Send %A_ThisHotkey%
-;  Return
-;!v::
-;  If IsInEmacsMode()
-;    scroll_up()
-;  Else
-;    Send %A_ThisHotkey%
-;  Return
++>^b::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    backward_char()
+    is_pre_spc = 0
+  }
+  Else
+    Send %A_ThisHotkey%
+  Return
+>^!w::
+  If IsInEmacsMode()
+    kill_ring_save()
+  Else
+    Send %A_ThisHotkey%
+  Return
+
+; page scroll are commented out
+>^v::
+  If IsInEmacsMode()
+   scroll_down()
+  Else
+   Send %A_ThisHotkey%
+Return
+>^!v::
+  If IsInEmacsMode()
+   scroll_up()
+  Else
+   Send %A_ThisHotkey%
+  Return
 
 
 ;==========================
@@ -450,38 +522,42 @@ SendCommand(emacsKey, translationToWindowsKeystrokes, secondWindowsKeystroke="")
 ;Word Navigation
 ;==========================
 
-$!p::SendCommand("!p","^{Up}")
+;$>^!p::SendCommand("!p","^{Up}")
 
-$!n::SendCommand("!n","^{Down}")
+;$>^!n::SendCommand("!n","^{Down}")
 
-$!f::SendCommand("!f","^{Right}")
+$>^!f::SendCommand("!f","^{Right}")
 
-$!b::SendCommand("!b","^{Left}")
+$+>^!f::SendCommand("+!f","+^{Right}")
+
+$>^!b::SendCommand("!b","^{Left}")
+
+$+>^!b::SendCommand("+!b","+^{Left}")
 
 ;==========================
 ;Page Navigation
 ;==========================
-$!<::SendCommand("!<","^{Home}")
+$>^!<::SendCommand("!<","^{Home}")
 
-$!>::SendCommand("!>","^{End}")
+$>^!>::SendCommand("!>","^{End}")
 
 ;==========================
 ;Undo
 ;==========================
 
-$^_::SendCommand("^_","^z")
+$>^_::SendCommand("^_","^z")
 
 ;==========================
 ;Delete
 ;==========================
-$!d::SendCommand("!d","^+{Right}","{Delete}")
+$>^!d::SendCommand("!d","^+{Right}","{Delete}")
 
 
 
 ;==========================
 ;Disable Win Key but not its combinations
 ;==========================
-~LWin Up:: return
+; ~LWin Up:: return
 
 ;==========================
 ;Auto Save
@@ -502,15 +578,15 @@ $!d::SendCommand("!d","^+{Right}","{Delete}")
 ;==========================
 ; Mac Key bindings
 ;==========================
-!w::Send {LCtrl Down}{w}{LCtrl Up}  ; emacs kill_ring_save()
-!t::Send {LCtrl Down}{t}{LCtrl Up}
-!c::Send {LCtrl Down}{c}{LCtrl Up}
-!v::Send {LCtrl Down}{v}{LCtrl Up}
-!l::Send {LCtrl Down}{l}{LCtrl Up}
-!q::Send {LAlt Down}{f4}{LAlt Up}
-!a::Send {LCtrl Down}{a}{LCtrl Up}
-!s::Send {LCtrl Down}{s}{LCtrl Up}
-!z::Send {LCtrl Down}{z}{LCtrl Up}
-!r::Send {LCtrl Down}{r}{LCtrl Up}
-!LButton::Send {LCtrl Down}{LButton}{LCtrl Up}
-!RButton::Send {LCtrl Down}{RButton}{LCtrl Up}
+; !w::Send {LCtrl Down}{w}{LCtrl Up}  ; emacs kill_ring_save()
+; !t::Send {LCtrl Down}{t}{LCtrl Up}
+; !c::Send {LCtrl Down}{c}{LCtrl Up}
+; !v::Send {LCtrl Down}{v}{LCtrl Up}
+; !l::Send {LCtrl Down}{l}{LCtrl Up}
+; !q::Send {LAlt Down}{f4}{LAlt Up}
+; !a::Send {LCtrl Down}{a}{LCtrl Up}
+; !s::Send {LCtrl Down}{s}{LCtrl Up}
+; !z::Send {LCtrl Down}{z}{LCtrl Up}
+; !r::Send {LCtrl Down}{r}{LCtrl Up}
+; !LButton::Send {LCtrl Down}{LButton}{LCtrl Up}
+; !RButton::Send {LCtrl Down}{RButton}{LCtrl Up}

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -66,12 +66,16 @@ SetEmacsMode(toActive) {
 ; WinActive("ahk_class Chrome_WidgetWin_1") ||
 ;==========================
 is_target() {
+  ; for disable
+  if (WinActive("ahk_exe emacs.exe")) {
+    return false
+  }
   ; force enable
-  if(WinActive("ahk_exe rider64.exe")) {
+  if (WinActive("ahk_exe rider64.exe")) {
     return true
   }
   ; for disable
-  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame")) {
+  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame") || WinActive("ahk_class Emacs")) {
     return false
   }
   return true
@@ -268,7 +272,8 @@ singleLetterFallbackToDefault() {
     Send +%A_ThisHotkey%  ; + for upper case
   }
   Else {
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   }
 }
 
@@ -281,7 +286,8 @@ singleLetterFallbackToDefault() {
     SetTimer, KeyX, 1000
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 
 h::
@@ -305,57 +311,66 @@ h::
         Send {Right}
     }
   } Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 
 +>^f::
   If IsInEmacsMode()
       Send +{Right}
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 
 >^d::
   If IsInEmacsMode()
     delete_char()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^k::
   If IsInEmacsMode()
     kill_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^o::
   If IsInEmacsMode()
     open_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^g::
   If IsInEmacsMode()
     quit()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^j::
   If IsInEmacsMode()
     newline_and_indent()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^m::
   If IsInEmacsMode()
     newline()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^i::
   If IsInEmacsMode()
     indent_for_tab_command()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^s::
   If IsInEmacsMode()
@@ -366,31 +381,36 @@ h::
       isearch_forward()
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^r::
   If IsInEmacsMode()
     isearch_backward()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^w::
   If IsInEmacsMode()
     kill_region()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^y::
   If IsInEmacsMode()
     yank()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^/::
   If IsInEmacsMode()
     undo()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^Space::
   If IsInEmacsMode()
@@ -401,13 +421,15 @@ h::
       is_pre_spc = 1
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^a::
   If IsInEmacsMode()
     move_beginning_of_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 +>^a::
   If IsInEmacsMode()
@@ -417,13 +439,15 @@ h::
     is_pre_spc = 0
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^e::
   If IsInEmacsMode()
     move_end_of_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
   If IsInEmacsMode()
   {
@@ -432,13 +456,15 @@ h::
     is_pre_spc = 0
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^p::
   If IsInEmacsMode()
     previous_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 +>^p::
   If IsInEmacsMode()
@@ -448,13 +474,15 @@ h::
     is_pre_spc = 0
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^n::
   If IsInEmacsMode()
     next_line()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 +>^n::
   If IsInEmacsMode()
@@ -464,13 +492,15 @@ h::
     is_pre_spc = 0
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^b::
   If IsInEmacsMode()
     backward_char()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 +>^b::
   If IsInEmacsMode()
@@ -480,13 +510,15 @@ h::
     is_pre_spc = 0
   }
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 >^!w::
   If IsInEmacsMode()
     kill_ring_save()
   Else
-    Send %A_ThisHotkey%
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
   Return
 
 ; page scroll are commented out

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -66,14 +66,15 @@ SetEmacsMode(toActive) {
 ; WinActive("ahk_class Chrome_WidgetWin_1") ||
 ;==========================
 is_target() {
-  ; }
+  ; force on for rider (ahk_class is SunAwtFrame)
   if (WinActive("ahk_exe rider64.exe")) {
     return true
   }
-  ; for disable
-  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame") || WinActive("ahk_class VirtualConsoleClass") || WinActive("ahk_class Emacs")) {
+  ; force off for various programs, mainly emacs
+  if (WinActive("ahk_class Emacs") || WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame") || WinActive("ahk_class VirtualConsoleClass")) {
     return false
   }
+  ; default to true
   return true
 }
 

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -453,7 +453,7 @@ h::
   Else
   {
     StringReplace, hotkey, A_ThisHotkey, >
-    Send %hotkey%
+    Send ^{Space}
   }
   Return
 >^a::

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -66,16 +66,12 @@ SetEmacsMode(toActive) {
 ; WinActive("ahk_class Chrome_WidgetWin_1") ||
 ;==========================
 is_target() {
-  ; for disable
-  if (WinActive("ahk_exe emacs.exe")) {
-    return false
-  }
-  ; force enable
+  ; }
   if (WinActive("ahk_exe rider64.exe")) {
     return true
   }
   ; for disable
-  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame") || WinActive("ahk_class Emacs")) {
+  if (WinActive("ahk_class Console_2_Main") || WinActive("ahk_class PuTTY") || WinActive("ahk_class SunAwtFrame") || WinActive("ahk_class VirtualConsoleClass") || WinActive("ahk_class Emacs")) {
     return false
   }
   return true
@@ -286,8 +282,10 @@ singleLetterFallbackToDefault() {
     SetTimer, KeyX, 1000
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 
 h::
@@ -319,58 +317,74 @@ h::
   If IsInEmacsMode()
       Send +{Right}
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 
 >^d::
   If IsInEmacsMode()
     delete_char()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^k::
   If IsInEmacsMode()
     kill_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^o::
   If IsInEmacsMode()
     open_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^g::
   If IsInEmacsMode()
     quit()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^j::
   If IsInEmacsMode()
     newline_and_indent()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^m::
   If IsInEmacsMode()
     newline()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^i::
   If IsInEmacsMode()
     indent_for_tab_command()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^s::
   If IsInEmacsMode()
@@ -381,36 +395,46 @@ h::
       isearch_forward()
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^r::
   If IsInEmacsMode()
     isearch_backward()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^w::
   If IsInEmacsMode()
     kill_region()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^y::
   If IsInEmacsMode()
     yank()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^/::
   If IsInEmacsMode()
     undo()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^Space::
   If IsInEmacsMode()
@@ -421,15 +445,19 @@ h::
       is_pre_spc = 1
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^a::
   If IsInEmacsMode()
     move_beginning_of_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 +>^a::
   If IsInEmacsMode()
@@ -439,17 +467,21 @@ h::
     is_pre_spc = 0
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^e::
   If IsInEmacsMode()
     move_end_of_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
-+>^e::  
++>^e::
   If IsInEmacsMode()
   {
     is_pre_spc = 1
@@ -457,15 +489,19 @@ h::
     is_pre_spc = 0
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^p::
   If IsInEmacsMode()
     previous_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 +>^p::
   If IsInEmacsMode()
@@ -475,15 +511,19 @@ h::
     is_pre_spc = 0
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^n::
   If IsInEmacsMode()
     next_line()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 +>^n::
   If IsInEmacsMode()
@@ -493,15 +533,19 @@ h::
     is_pre_spc = 0
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^b::
   If IsInEmacsMode()
     backward_char()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 +>^b::
   If IsInEmacsMode()
@@ -511,15 +555,19 @@ h::
     is_pre_spc = 0
   }
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 >^!w::
   If IsInEmacsMode()
     kill_ring_save()
   Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 
 ; page scroll are commented out

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -60,13 +60,22 @@ SetEmacsMode(toActive) {
   Send {Shift Up}
 }
 
+
+;==========================
+; temp 
+;==========================
+>^<^!C::ToggleCapsLock()
+ToggleCapsLock() {
+SetCapsLockState, AlwaysOff ; diable the CapsLock key
+}
+
 ;==========================
 ;is target
 ; WinActive("ahk_class Chrome_WidgetWin_1") ||
 ;==========================
 is_target() {
-  ; force on for rider (ahk_class is SunAwtFrame)
-  if (WinActive("ahk_exe rider64.exe")) {
+  ; force on for rider and clion (ahk_class is SunAwtFrame)
+  if (WinActive("ahk_exe rider64.exe") || WinActive("ahk_exe clion64.exe")) {
     return true
   }
   ; force off for various programs, mainly emacs
@@ -259,6 +268,24 @@ scroll_down() {
     Send +{PgDn}
   Else
     Send {PgDn}
+  Return
+}
+
+backward_word() {
+  global
+  if is_pre_spc
+    Send +^{Left}
+  Else
+    Send ^{Left}
+  Return
+}
+
+forward_word() {
+  global
+  if is_pre_spc
+    Send +^{Right}
+  Else
+    Send ^{Left}
   Return
 }
 
@@ -581,15 +608,69 @@ h::
   If IsInEmacsMode()
    scroll_down()
   Else
-   Send %A_ThisHotkey%
-Return
+  {
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
+  }
+  Return
+
 >^!v::
   If IsInEmacsMode()
    scroll_up()
   Else
-   Send %A_ThisHotkey%
+  {
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
+  }
   Return
 
+>^!f::
+  If IsInEmacsMode()
+   forward_word()
+  Else
+  {
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
+  }
+  Return
+
++>^!f::
+  If IsInEmacsMode()
+  {
+   is_pre_spc=1
+   forward_word()
+   is_pre_spc=0
+  }
+  Else
+  {
+   StringReplace, hotkey, A_ThisHotkey, >
+   Send %hotkey%
+  }
+  Return
+
+>^!b::
+  If IsInEmacsMode()
+    backward_word()
+  Else
+  {
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
+  }
+  Return
+
++>^!b::
+  If IsInEmacsMode()
+  {
+    is_pre_spc = 1
+    backward_word()
+    is_pre_spc = 0
+  }
+  Else
+  {
+    StringReplace, hotkey, A_ThisHotkey, >
+    Send %hotkey%
+  }
+  Return
 
 ;==========================
 ;Original
@@ -613,13 +694,13 @@ SendCommand(emacsKey, translationToWindowsKeystrokes, secondWindowsKeystroke="")
 
 ;$>^!n::SendCommand("!n","^{Down}")
 
-$>^!f::SendCommand("!f","^{Right}")
+;$>^!f::SendCommand("!f","^{Right}")
 
-$+>^!f::SendCommand("+!f","+^{Right}")
+;$+>^!f::SendCommand("+!f","+^{Right}")
 
-$>^!b::SendCommand("!b","^{Left}")
+;$>^!b::SendCommand("!b","^{Left}")
 
-$+>^!b::SendCommand("+!b","+^{Left}")
+;$+>^!b::SendCommand("+!b","+^{Left}")
 
 ;==========================
 ;Page Navigation

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -449,6 +449,7 @@ h::
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
   Return
++>^e::  
   If IsInEmacsMode()
   {
     is_pre_spc = 1

--- a/EmacsEverywhere.ahk
+++ b/EmacsEverywhere.ahk
@@ -27,7 +27,6 @@ is_pre_spc = 0
 EmacsModeStat := false
 SetEmacsMode(true)
 
-
 ;==========================
 ;Timer Subroutine
 ;==========================
@@ -265,10 +264,12 @@ scroll_down() {
 
 singleLetterFallbackToDefault() {
   state := GetKeyState("Capslock", "T")
-  If(state) {
+  If(state)
+  {
     Send +%A_ThisHotkey%  ; + for upper case
   }
-  Else {
+  Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
   }
@@ -299,7 +300,8 @@ h::
   Return
 
 >^f::
-  If IsInEmacsMode() {
+  If IsInEmacsMode()
+  {
     If is_pre_x {
       Send ^o
       global is_pre_x = 0
@@ -309,9 +311,12 @@ h::
       Else
         Send {Right}
     }
-  } Else
+  }
+  Else
+  {
     StringReplace, hotkey, A_ThisHotkey, >
     Send %hotkey%
+  }
   Return
 
 +>^f::


### PR DESCRIPTION
Removes CapsLock and binds CapsLock to Right Control.
Uses Caps/RCtrl as an emacs Ctrl key whenever an emacs Ctrl hotkey is used e.g. C-f
Uses Caps/RCtrl + Alt as an emacs Alt key whenever an emacs Alt hotkey is used e.g. M-f